### PR TITLE
Implement automatic reload and remove reload button

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ You can choose from bundled examples or can modify it by yourself.
 If unchecked, the effect file will be read one time. If another source try to read the same file, cache will be used.
 If checked, the cache is disabled. This will be useful to reload the effect file when you debug the effect file.
 
-### Reload
-**Deprecated**
-Click this button if you need to reload the effect file. This button is available if `Do not use cache` is checked.
-
 ### Number of sources
 Set number of sources sent to the effect file.
 Some effect files in the example only support 2 for this property.


### PR DESCRIPTION
Same as other standard sources like text sources, automatic reload is implemented to replace the reload button implemented in aa14032, #6.
The idea was discussed on an issue #5.


<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
